### PR TITLE
【Fixed】rails g コマンドの際に、いらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,10 @@ module Tsubuyaiter
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
 
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#2 

- `rails g` コマンド実行の際に、assetsファイル、helperファイルが作成されないように改善